### PR TITLE
Adding Agent Replay Buffer. 

### DIFF
--- a/configs/meltingpot.yaml
+++ b/configs/meltingpot.yaml
@@ -1,3 +1,5 @@
+resume: False
+run_id: none
 seed: 41
 batch_size: 512
 wandb: 'online'

--- a/configs/meltingpot.yaml
+++ b/configs/meltingpot.yaml
@@ -117,3 +117,4 @@ training:
   spr_weight: 0
   normalize_advantages: True
   actor_loss_mode: 'integrated_aa'
+  add_to_agent_replay_buffer_every: 20

--- a/configs/meltingpot.yaml
+++ b/configs/meltingpot.yaml
@@ -1,5 +1,5 @@
 resume: False
-run_id: none
+run_id: null
 seed: 41
 batch_size: 512
 wandb: 'online'

--- a/configs/meltingpot.yaml
+++ b/configs/meltingpot.yaml
@@ -22,6 +22,8 @@ max_cxt_len: 70
 run_single_agent: False
 debug_mode: False
 use_ss_loss: False
+agent_rb_size: 0
+agent_rb_mode: 'off'
 
 env:
   type: 'meltingpot'

--- a/decoder.py
+++ b/decoder.py
@@ -204,7 +204,7 @@ class CausalSelfAttention(nn.Module):
         self.resid_drop = nn.Dropout(config.resid_pdrop)
         self.proj = nn.Linear(config.embed_dim, config.embed_dim)
         causal_mask = torch.tril(torch.ones(config.max_seq_len, config.max_seq_len))
-        self.register_buffer('mask', causal_mask)
+        self.register_buffer('mask', causal_mask, persistent=False)
         self.attention_impl = config.attention_impl
 
     def forward(self, x: torch.Tensor, past_kv: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> torch.Tensor:

--- a/notebooks/advantage_lab.ipynb
+++ b/notebooks/advantage_lab.ipynb
@@ -17,6 +17,27 @@
   {
    "metadata": {},
    "cell_type": "code",
+   "source": [
+    "import numpy as np\n",
+    "frac = []\n",
+    "for seed in range(10000):\n",
+    "    # seed numpy \n",
+    "    np.random.seed(seed) \n",
+    "    n = 20\n",
+    "    agent_advantages = np.random.rand(n) * 2 - 1 \n",
+    "    opponent_advantages = agent_advantages\n",
+    "    frc = ((np.cumsum(agent_advantages)[:-1] * opponent_advantages[1:])).mean()\n",
+    "    frac.append(frc)\n",
+    "\n",
+    "print(sum(frac) / len(frac))"
+   ],
+   "id": "bdc136b9efb15840",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
    "source": "agent_advantages",
    "id": "78fa4f25683f76ac",
    "outputs": [],
@@ -94,6 +115,14 @@
    "cell_type": "code",
    "source": "",
    "id": "efbe0a54db1dcacb",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
+   "id": "eaea53135aad838c",
    "outputs": [],
    "execution_count": null
   }

--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ class PositionalEncoding(nn.Module):
         pe = torch.zeros(max_len, 1, d_model)
         pe[:, 0, 0::2] = torch.sin(position * div_term)
         pe[:, 0, 1::2] = torch.cos(position * div_term)
-        self.register_buffer('pe', pe)
+        self.register_buffer('pe', pe, persistent=False)
 
     def forward(self, x):
         """

--- a/train.py
+++ b/train.py
@@ -457,6 +457,8 @@ class AgentReplayBuffer:
         self.agent_number = agent_number
 
     def add_agent(self, agent):
+        if self.agents[self.marker] is not None:
+            del self.agents[self.marker]
         self.agents[self.marker] = agent.state_dict()
         self.num_added_agents += 1
         self.marker = (self.marker + 1) % self.replay_buffer_size
@@ -589,7 +591,7 @@ class TrainingAlgorithm(ABC):
             update_target_network(agent.target, agent.critic, self.train_cfg.tau)
             # --- update agent replay buffer ---
             if self.agent_replay_buffer_mode != "off":
-                self.agent_replay_buffer.add_agent(copy.deepcopy(agent))
+                self.agent_replay_buffer.add_agent(agent)
 
         train_step_metrics.update({
             "critic_loss": critic_loss.detach(),

--- a/train.py
+++ b/train.py
@@ -484,7 +484,11 @@ class GPUMemoryFriendlyAgentReplayBuffer:
         self.marker = 0
         self.num_added_agents = 0
         agent_blueprint = instantiate_agent(self.main_cfg)
-        batched_state_dicts = {k: torch.zeros((replay_buffer_size, *v.shape), device=v.device) for k, v in agent_blueprint.state_dict().items()}
+        batched_state_dicts = {}
+        for k in agent_blueprint.state_dict().keys():
+            print(k)
+            v = agent_blueprint.state_dict()[k]
+            batched_state_dicts[k] = torch.zeros((replay_buffer_size, *v.shape), device=v.device)
         self.agents_batched_state_dicts = batched_state_dicts
         self.agent_number = agent_number
 

--- a/train.py
+++ b/train.py
@@ -486,7 +486,6 @@ class GPUMemoryFriendlyAgentReplayBuffer:
         agent_blueprint = instantiate_agent(self.main_cfg)
         batched_state_dicts = {}
         for k in agent_blueprint.state_dict().keys():
-            print(k)
             v = agent_blueprint.state_dict()[k]
             batched_state_dicts[k] = torch.zeros((replay_buffer_size, *v.shape), device=v.device)
         self.agents_batched_state_dicts = batched_state_dicts

--- a/train.py
+++ b/train.py
@@ -767,7 +767,7 @@ class AdvantageAlignment(TrainingAlgorithm):
 
         A_2s = torch.vmap(other_A_s, in_dims=(0, None))(A_s.view(B, N, -1), N).reshape((B * N, -1))
         assert torch.allclose(A_s[1:N].sum(dim=0), A_2s[0]), "aa loss is buggy :)"
-        return (A_1s * A_2s) / torch.arange(1, A_s.shape[-1]+1)
+        return (A_1s * A_2s) / torch.arange(1, A_s.shape[-1]+1, device=device)
 
     def aa_loss(self, A_s, log_ps, old_log_ps):
         B = self.batch_size

--- a/train.py
+++ b/train.py
@@ -548,6 +548,7 @@ class TrainingAlgorithm(ABC):
         self,
         trajectory,
         agents,
+        step: int,
         optimize_critic=True,
     ):
 
@@ -628,7 +629,7 @@ class TrainingAlgorithm(ABC):
             # --- update target network ---
             update_target_network(agent.target, agent.critic, self.train_cfg.tau)
             # --- update agent replay buffer ---
-            if self.agent_replay_buffer_mode != "off":
+            if self.agent_replay_buffer_mode != "off" and step % self.train_cfg.add_to_agent_replay_buffer_every == 0:
                 self.agent_replay_buffer.add_agent(agent)
 
         train_step_metrics.update({
@@ -707,7 +708,8 @@ class TrainingAlgorithm(ABC):
             train_step_metrics = self.train_step(
                 trajectory=trajectory,
                 agents=self.agents,
-                optimize_critic=True
+                step=step,
+                optimize_critic=True,
             )
 
             for key, value in train_step_metrics.items():

--- a/utils.py
+++ b/utils.py
@@ -103,9 +103,9 @@ def save_checkpoint(agent, replay_buffer, agent_replay_buffer, step, checkpoint_
     # Get the W&B run ID
     run_id = wandb.run.id
 
-    from train import ReplayBuffer, AgentReplayBuffer
+    from train import ReplayBuffer, GPUMemoryFriendlyAgentReplayBuffer
     replay_buffer: ReplayBuffer
-    agent_replay_buffer: AgentReplayBuffer
+    agent_replay_buffer: GPUMemoryFriendlyAgentReplayBuffer
 
     # Create a folder with the run ID if it doesn't exist
     run_folder = Path(checkpoint_dir) / run_id
@@ -118,15 +118,14 @@ def save_checkpoint(agent, replay_buffer, agent_replay_buffer, step, checkpoint_
     agent_checkpoint = {
         'actor_state_dict': agent.actor.state_dict(),
         'critic_state_dict': agent.critic.state_dict(),
-        'target_state_dict': agent.target.state_dict(),
+        'target_state_dict': agent.target.state_dict(), # todo: remove all this and just use the state_dict of the agent
     }
 
     torch.save(agent_checkpoint, checkpoint_path / 'agent.pt')
     if replay_buffer is not None:
         torch.save(replay_buffer.trajectory_batch.data, checkpoint_path / 'replay_buffer_data.pt')
     if agent_replay_buffer is not None:
-        agents_state_dict = [agent_state_dict for agent_state_dict in agent_replay_buffer.agents if agent_state_dict is not None]
-        torch.save(agents_state_dict, checkpoint_path / 'agent_replay_buffer_state_dicts.pt')
+        torch.save({'params': agent_replay_buffer.agents_batched_state_dicts, 'num_added_agents': agent_replay_buffer.num_added_agents}, checkpoint_path / 'agent_replay_buffer.pt')
     print(f"(@@-o)Agent Checkpoint saved at: {checkpoint_path}")
 
 

--- a/visualization.py
+++ b/visualization.py
@@ -20,7 +20,7 @@ from utils import (
 
 num_frames = 1000
 model_folder = 'experiments'
-model_name = 'ewo1jd39/model_3000.pt'
+model_name = 'ewo1jd39/step_1000/agent.pt'
 output_folder = 'videos'
 
 def create_video_with_imageio(frames, output_folder, video_name='output.mp4', frame_rate=3):


### PR DESCRIPTION
Implement agent replay buffer capability. Currently also trains on the off policy data gathered by the old agent copies. Maybe we should later just train on the on policy data. But things are working now. 